### PR TITLE
fix: support underscore in image names

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Docker build and push image
         run: >
           cd app &&
-          TAG_ARGS=$(echo -n "$IMAGE_TAGS" | sed -r "s_([^ :/]+)_ --tag $REGISTRY/$IMAGE_NAME:\1 _g") &&
+          TAG_ARGS=$(echo -n "$IMAGE_TAGS" | sed -r "s#([^ :/]+)# --tag $REGISTRY/$IMAGE_NAME:\1 #g") &&
           docker build 
           --label org.opencontainers.image.url="$FULL_REPO_URL"
           --label org.opencontainers.image.revision="$COMMIT_HASH"


### PR DESCRIPTION
A sed command is currently using underscores as pattern delimiters, which breaks when the value of $IMAGE_NAME contains an underscore. Using hash (#) as delimiter, since it is not a valid character in container image names and thus can be used without issue here.